### PR TITLE
Fix puppeteer credentials input

### DIFF
--- a/src/activate-license.js
+++ b/src/activate-license.js
@@ -17,7 +17,7 @@ async function run() {
         if (unitySerial) {
             await unity.activateSerialLicense(unityPath, unityUsername, unityPassword, unitySerial);
         } else {
-            await exec.exec('npm install puppeteer@"^5.x"', [], { cwd: path.join(__dirname, '..') }); // install puppeteer for current platform
+            await exec.exec('npm install puppeteer@"^13.x"', [], { cwd: path.join(__dirname, '..') }); // install puppeteer for current platform
             const licenseRobot = require('./license-robot');
             const licenseRequestFile = await unity.createManualActivationFile(unityPath);
             const licenseData = await licenseRobot.getPersonalLicense(licenseRequestFile, unityUsername, unityPassword, unityAuthenticatorKey);

--- a/src/license-robot.js
+++ b/src/license-robot.js
@@ -40,9 +40,12 @@ async function browser_getPersonalLicense(licenseRequestData, username, password
  */
 async function licensePage_login(page, username, password, authenticatorKey) {
     console.log("License robot. Login...");
-    await page.waitForSelector('#conversations_create_session_form_email');
-    await page.type('#conversations_create_session_form_email', username);
-    await page.type('#conversations_create_session_form_password', password);
+
+    await page.waitForSelector("#conversations_create_session_form_email");
+
+    await page.evaluate((x) => { document.getElementById("conversations_create_session_form_email").value = x; }, username);
+    await page.evaluate((x) => { document.getElementById("conversations_create_session_form_password").value = x; }, password);
+
     await Promise.all([
         page.click('input[name=commit]'),
         page.waitForNavigation({ waitUntil: 'networkidle0' })


### PR DESCRIPTION
Fixes an issue where most of the time `page.type` for whatever reason wasn't typing the full text correctly, setting the value directly is faster anyway and works.

Closes #3