### PR TITLE
Fix return license for Unity 2021.3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "activate unity action",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redemptiongames/activate-unity.git"
+    "url": "git+https://github.com/kuler90/activate-unity.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "activate unity action",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kuler90/activate-unity.git"
+    "url": "git+https://github.com/redemptiongames/activate-unity.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/return-license.js
+++ b/src/return-license.js
@@ -8,7 +8,9 @@ async function run() {
             throw new Error('unity path not found');
         }
         if (core.getInput('unity-serial')) {
-            await unity.returnLicense(unityPath);
+            const unityUsername = core.getInput('unity-username', { required: true });
+            const unityPassword = core.getInput('unity-password', { required: true });
+            await unity.returnLicense(unityPath, unityUsername, unityPassword);
         }
     } catch (error) {
         core.setFailed(error.message);

--- a/src/unity.js
+++ b/src/unity.js
@@ -25,7 +25,7 @@ async function activateManualLicense(unityPath, licenseData) {
 }
 
 async function returnLicense(unityPath) {
-    await executeUnity(unityPath, '-batchmode -nographics -quit -logFile "-" -returnlicense');
+    await executeUnity(unityPath, `-batchmode -nographics -quit -logFile "-" -returnlicense -username "${username}" -password "${password}"`);
 }
 
 async function executeUnity(unityPath, args) {

--- a/src/unity.js
+++ b/src/unity.js
@@ -24,7 +24,7 @@ async function activateManualLicense(unityPath, licenseData) {
     }
 }
 
-async function returnLicense(unityPath) {
+async function returnLicense(unityPath, username, password) {
     await executeUnity(unityPath, `-batchmode -nographics -quit -logFile "-" -returnlicense -username "${username}" -password "${password}"`);
 }
 


### PR DESCRIPTION
Requires passing username and password on the command line. Fix verified.